### PR TITLE
Fixing date loading

### DIFF
--- a/lib/theoj/paper.rb
+++ b/lib/theoj/paper.rb
@@ -1,3 +1,4 @@
+require "date"
 require "find"
 require "yaml"
 require "rugged"
@@ -108,9 +109,9 @@ module Theoj
         @paper_metadata ||= if paper_path.nil?
           {}
         elsif paper_path.include?('.tex')
-          YAML.load_file(paper_path.gsub('.tex', '.yml'))
+          YAML.safe_load(File.read(paper_path.gsub('.tex', '.yml')), permitted_classes: [Date])
         else
-          YAML.load_file(paper_path)
+          YAML.safe_load(File.read(paper_path), permitted_classes: [Date])
         end
       end
 


### PR DESCRIPTION
:Wave: @xuanxu – we're getting a fair number of these errors: https://github.com/openjournals/joss-papers/actions/runs/15083543965/job/42403305917

Which I think is because of the date formatting that some authors are using and Psych is trying to load the `Date` class. I believe this change fixes the issue, but have not built and tested the gem locally.

Possibly fixes https://github.com/openjournals/joss/issues/1429