### PR TITLE
Strip <code> tags from titles too

### DIFF
--- a/lib/theoj/submission.rb
+++ b/lib/theoj/submission.rb
@@ -187,7 +187,7 @@ module Theoj
 
     def plaintext(t)
       parsed_title = Commonmarker.to_html(t.strip, options:{ render: { hardbreaks: false } })
-      parsed_title.gsub("\n", "").gsub(" ", " ").gsub(/\A<p>/, "").gsub(/<\/p>\z/, "").gsub("<span data-escaped-char>", "").gsub("<span>", "").gsub(/<\/span>/, "")
+      parsed_title.gsub("\n", "").gsub(" ", " ").gsub(/\A<p>/, "").gsub(/<\/p>\z/, "").gsub("<span data-escaped-char>", "").gsub("<span>", "").gsub(/<\/span>/, "").gsub("<!-- raw HTML omitted -->", "")
     end
 
     def format_date(date_string)

--- a/spec/lib/submission_spec.rb
+++ b/spec/lib/submission_spec.rb
@@ -62,10 +62,10 @@ describe Theoj::Submission do
   it "generates a plain text version of the title" do
     @submission.paper = Theoj::Paper.new("repository", "branch", fixture("paper_metadata_markup_title.md"))
 
-    markup_title = "test\\_lib: A mesh generator for automatic, efficient, and robust mesh&nbsp;generation for large-scale cosmological modeling and simulation"
+    markup_title = "test\\_lib: A <code>mesh</code> generator for automatic, efficient, and robust mesh&nbsp;generation for large-scale cosmological modeling and simulation"
     expect(@submission.paper.title).to eq(markup_title)
 
-    expected_title = "test_lib: A mesh generator for automatic, efficient, and robust mesh generation for large-scale cosmological modeling and simulation"
+    expected_title = "test_lib: A mesh generator for automatic, efficient, and robust mesh generation for large-scale cosmological modeling and simulation"
     expect(@submission.metadata_info[:title]).to eq(expected_title)
   end
 

--- a/spec/support/fixtures/paper_metadata_markup_title.md
+++ b/spec/support/fixtures/paper_metadata_markup_title.md
@@ -1,5 +1,5 @@
 ---
-title: 'test\_lib: A mesh generator for automatic, efficient, and robust mesh&nbsp;generation for large-scale cosmological modeling and simulation'
+title: 'test\_lib: A <code>mesh</code> generator for automatic, efficient, and robust mesh&nbsp;generation for large-scale cosmological modeling and simulation'
 tags:
   - Python
   - electronic structure theory


### PR DESCRIPTION
We semi-regularly get papers where people have used the `<code>` tag in the titles. I *think* this PR strips that before the metadata are submitted to JOSS.